### PR TITLE
Update PyPI issuer

### DIFF
--- a/pack.json
+++ b/pack.json
@@ -4840,7 +4840,7 @@
             "filename": "SVG/Python Package Index.svg",
             "category": "1. Apps & Sites",
             "issuer": [
-                "Python Package Index"
+                "PyPI"
             ]
         },
         {


### PR DESCRIPTION
The issuer of the Python Package Index is "PyPI", this PR is just an update of the issuer!